### PR TITLE
Changes to mean nb of tracks contributing and successive convolutions

### DIFF
--- a/src/AT_PhysicsRoutines.c
+++ b/src/AT_PhysicsRoutines.c
@@ -765,27 +765,15 @@ double AT_mean_number_of_tracks_contrib(    const long number_of_field_component
                 const long er_model,
                 const long stopping_power_source_no)
 {
-  double* norm_fluence    =  (double*)calloc(number_of_field_components, sizeof(double));
-  double total_D_Gy       =  AT_total_D_Gy( number_of_field_components, E_MeV_u, particle_no, fluence_cm2, material_no, stopping_power_source_no);
-
-  AT_normalize( number_of_field_components, fluence_cm2, norm_fluence);
-
-  double u                =  0.0;
+  double mu                =  0.0;
   long i;
   for (i = 0; i < number_of_field_components; i++){
-    double single_impact_fluence_cm2 =  AT_single_impact_fluence_cm2_single(  E_MeV_u[i], material_no, er_model);
-    double LET_MeV_cm2_g;
-    	  AT_Mass_Stopping_Power_with_no( stopping_power_source_no,
-    			  1,
-    			  &E_MeV_u[i],
-    			  &particle_no[i],
-    			  material_no,
-    			  &LET_MeV_cm2_g);
-    u += norm_fluence[i] * AT_single_impact_dose_Gy_single(  LET_MeV_cm2_g, single_impact_fluence_cm2 );
+    double max_electron_range_m = AT_max_electron_range_m(E_MeV_u[i], (int)material_no, (int)er_model);
+    mu += fluence_cm2[i] * M_PI * gsl_pow_2( max_electron_range_m * m_to_cm );
   }
 
-  free(norm_fluence);
-  return(total_D_Gy / u);
+  return(mu);
+
 }
 
 double AT_kinetic_variable_single(double E_MeV_u){

--- a/src/AT_SuccessiveConvolutions.c
+++ b/src/AT_SuccessiveConvolutions.c
@@ -142,11 +142,18 @@ void  AT_single_impact_local_dose_distrib(
 			fluence_cm2[i] = fluence_cm2_or_dose_Gy[i];
 		}
 	}
-	double*  norm_fluence                                 =  (double*)calloc(n, sizeof(double));
-	AT_normalize(    n,
-			fluence_cm2,
-			norm_fluence);
+
+
+	double*  nb_tracks_contrib                              =  (double*)calloc(n, sizeof(double));
+	for (i = 0; i < n; i++){
+    nb_tracks_contrib[i] = AT_mean_number_of_tracks_contrib(1,&E_MeV_u[i],&particle_no[i],&fluence_cm2[i],material_no,er_model,stopping_power_source_no);
+  }
 	free( fluence_cm2 );
+
+	double*  norm_nb_tracks_contrib                         =  (double*)calloc(n, sizeof(double));
+	AT_normalize(    n,
+			nb_tracks_contrib,
+			norm_nb_tracks_contrib);
 
 	/*
 	 * Prepare single impact local dose distribution histogram
@@ -298,7 +305,7 @@ void  AT_single_impact_local_dose_distrib(
 				double f1_comp;
 				for (j = 0; j < n_bins_f1_comp; j++){
 					f1_comp				  						=  (F1_comp[j] - F1_comp[j + 1]) / (dose_left_limits_Gy_F1_comp[j + 1] - dose_left_limits_Gy_F1_comp[j]);
-					frequency_1_Gy_f1[lowest_bin_no_comp + j]   += norm_fluence[i] * f1_comp;
+					frequency_1_Gy_f1[lowest_bin_no_comp + j]   += norm_nb_tracks_contrib[i] * f1_comp;
 				}
 
 				// adjust the density in first and last bin, because upper limit is not d.max.Gy and lower not d.min.Gy
@@ -307,7 +314,7 @@ void  AT_single_impact_local_dose_distrib(
 				free(F1_comp);
 			}
 			else{ // in case of n_bins_df == 1 (all doses fall into single bin, just add a value of 1.0
-				frequency_1_Gy_f1[lowest_bin_no_comp ]        +=  norm_fluence[i] * 1.0 / f1_dd_Gy[lowest_bin_no_comp];
+				frequency_1_Gy_f1[lowest_bin_no_comp ]        +=  norm_nb_tracks_contrib[i] * 1.0 / f1_dd_Gy[lowest_bin_no_comp];
 			}
 
 			// remember highest bin used
@@ -333,7 +340,7 @@ void  AT_single_impact_local_dose_distrib(
 				j, f1_d_Gy[j], f1_dd_Gy[j], frequency_1_Gy_f1[j]);
 	}
 	fclose(output);
-	free( norm_fluence );
+	free( norm_nb_tracks_contrib );
 }
 
 


### PR DESCRIPTION
This pull request introduce the following changes:
- correct the computation of the mean number of tracks contributing in a representative point of the mixed field
- changes the weighting of the field components in the computation of F1(d) for the successive convolutions from the relative fluence to relative number of tracks contributing