### PR TITLE
Incorrect doxygen comments fixed (no parameter description)

### DIFF
--- a/include/AT_DataParticle.h
+++ b/include/AT_DataParticle.h
@@ -317,7 +317,7 @@ int AT_particle_name_from_particle_no( const long  n,
  * Returns particle names for given particle numbers
  * @param[in]  n              TODO
  * @param[in]  particle_name  particle names
- * @param[out] corresponding  particle numbers
+ * @param[out] particle_no    TODO
  * @return status
  */
 int AT_particle_no_from_particle_name( const long  n,

--- a/include/AT_DataParticle.h
+++ b/include/AT_DataParticle.h
@@ -317,7 +317,7 @@ int AT_particle_name_from_particle_no( const long  n,
  * Returns particle names for given particle numbers
  * @param[in]  n              TODO
  * @param[in]  particle_name  particle names
- * @param[out] particle_no    TODO
+ * @param[in]  particle_no  type of the particles
  * @return status
  */
 int AT_particle_no_from_particle_name( const long  n,

--- a/include/AT_EnergyLoss.h
+++ b/include/AT_EnergyLoss.h
@@ -177,7 +177,11 @@ void AT_lambda_landau_from_energy_loss_multi( const long n,
 		double lambda_landau[]);
 
 /**
- *
+ * @param[in]  	   energy_loss_keV          TODO
+ * @param[in]  	   E_MeV_u      		    TODO
+ * @param[in]  	   particle_no      		TODO
+ * @param[in]  	   material_no      		TODO
+ * @param[in]  	   slab_thickness_um     	TODO
  * @return
  */
 double AT_lambda_landau_from_energy_loss_single( const double energy_loss_keV,
@@ -357,7 +361,11 @@ void AT_lambda_vavilov_from_energy_loss_multi( const long n,
 		double lambda_vavilov[]);
 
 /**
- *
+ * @param[in]  	   energy_loss_keV          TODO
+ * @param[in]  	   E_MeV_u      		    TODO
+ * @param[in]  	   particle_no      		TODO
+ * @param[in]  	   material_no      		TODO
+ * @param[in]  	   slab_thickness_um     	TODO
  * @return
  */
 double AT_lambda_vavilov_from_energy_loss_single( const double energy_loss_keV,

--- a/include/AT_EnergyLoss.h
+++ b/include/AT_EnergyLoss.h
@@ -178,9 +178,11 @@ void AT_lambda_landau_from_energy_loss_multi( const long n,
 
 /**
  * @param[in]  	   energy_loss_keV          TODO
- * @param[in]  	   E_MeV_u      		    TODO
- * @param[in]  	   particle_no      		TODO
- * @param[in]  	   material_no      		TODO
+ * @param[in]  E_MeV_u      energy of particle per nucleon [MeV/u]
+ * @param[in]  particle_no  type of the particles
+ * @see          AT_DataParticle.h for definition
+ * @param[in]  material_no  material index
+ * @see          AT_DataMaterial.h for definition
  * @param[in]  	   slab_thickness_um     	TODO
  * @return
  */
@@ -362,9 +364,11 @@ void AT_lambda_vavilov_from_energy_loss_multi( const long n,
 
 /**
  * @param[in]  	   energy_loss_keV          TODO
- * @param[in]  	   E_MeV_u      		    TODO
- * @param[in]  	   particle_no      		TODO
- * @param[in]  	   material_no      		TODO
+ * @param[in]  E_MeV_u      energy of particle per nucleon [MeV/u]
+ * @param[in]  particle_no  type of the particles
+ * @see          AT_DataParticle.h for definition
+ * @param[in]  material_no  material index
+ * @see          AT_DataMaterial.h for definition
  * @param[in]  	   slab_thickness_um     	TODO
  * @return
  */

--- a/include/AT_GammaResponse.h
+++ b/include/AT_GammaResponse.h
@@ -160,7 +160,7 @@ long AT_Gamma_number_of_parameters( const long Gamma_no );
  * @param[in]  gamma_model      gamma response model index
  * @param[in]  gamma_parameter  vector holding necessary parameters for the chose gamma response model (array of size 9)
  * @param[in]  lethal_event_mode  if true computation is done in lethal event mode
- * @param[out] response         gamma responses (array of size number_of_doses)
+ * @param[out] S         gamma responses (array of size number_of_doses)
  */
 void AT_gamma_response( const long  number_of_doses,
     const double   d_Gy[],
@@ -235,6 +235,7 @@ double AT_get_ion_response_from_response_distribution(  const long  number_of_bi
  * @param[in]  gamma_model               gamma response model index
  * @param[in]  gamma_parameter           vector holding necessary parameters for the chose gamma response model (array of size GR_MAX_NUMBER_OF_PARAMETERS)
  * @param[in]  lethal_events_mode        if true computation is done in lethal event mode
+ * @param[in]  dose_Gy_bin_width        TODO
  * @return     resulting ion response
  */
 double AT_get_ion_response_from_dose_distribution(  const long  number_of_bins,
@@ -255,6 +256,7 @@ double AT_get_ion_response_from_dose_distribution(  const long  number_of_bins,
  * @param[in]  gamma_model               gamma response model index
  * @param[in]  gamma_parameter           vector holding necessary parameters for the chose gamma response model (array of size GR_MAX_NUMBER_OF_PARAMETERS)
  * @param[in]  lethal_events_mode        if true computation is done in lethal event mode
+ * @param[in]  dose_Gy_bin_width        TODO
  * @return     relative efficiency
  */
 double AT_get_ion_efficiency_from_dose_distribution(  const long  number_of_bins,
@@ -276,6 +278,7 @@ double AT_get_ion_efficiency_from_dose_distribution(  const long  number_of_bins
  * @param[in]  gamma_model               gamma response model index
  * @param[in]  gamma_parameter           vector holding necessary parameters for the chose gamma response model (array of size GR_MAX_NUMBER_OF_PARAMETERS)
  * @param[in]  lethal_events_mode        if true computation is done in lethal event mode
+ * @param[in]  dose_Gy_bin_width        TODO
  */
 double AT_get_ion_efficiency_from_response_distribution(  const long  number_of_bins,
 	    const double   dose_Gy_bin_position[],

--- a/include/AT_ProbabilityDistributions.h
+++ b/include/AT_ProbabilityDistributions.h
@@ -92,6 +92,7 @@ double ROOT_vav_pdf(const double x, const ROOT_GXXXC1 * init);
  * IDF of Vavilov distribution
  * The code is based on ROOT VavilovFast class (which in turn is translated from CERNLIB G115 VAVRAN method)
  * @param[in] X - random number from uniform distribution [0,1]
+ * @param[in] init   TODO
  * @return Vavilov random number
  */
 double ROOT_val_idf(const double X, const ROOT_GXXXC1 *init);

--- a/include/AT_ProtonAnalyticalModels.h
+++ b/include/AT_ProtonAnalyticalModels.h
@@ -183,6 +183,7 @@ enum AT_RBEModels {
  * @param[in] eps              fraction of primary fluence contributing to the tail of energy spectrum
  * if negative a default value of 0.03 is assumed
  * @param[in] ref_alpha_beta_ratio   ratio of alpha to beta (parameters in linear-quadratic model) for reference radiation
+ * @param[in] rbe_model_no   TODO
  * @return                    proton RBE
  */
 double AT_proton_RBE_single(const double z_cm,
@@ -205,6 +206,7 @@ double AT_proton_RBE_single(const double z_cm,
  * @param[in] eps               fraction of primary fluence contributing to the tail of energy spectrum
  * if negative a default value of 0.03 is assumed
  * @param[in]  ref_alpha_beta_ratio   ratio of alpha to beta (parameters in linear-quadratic model) for reference radiation
+ * @param[in]  rbe_model_no   TODO
  * @param[out] rbe             proton RBE (array of size n)
  */
 void AT_proton_RBE_multi(const long n,

--- a/include/AT_RDD_Tabulated.h
+++ b/include/AT_RDD_Tabulated.h
@@ -105,8 +105,10 @@ double	 AT_r_max_RadicalDiffusion_m( const double E_MeV_u);
  * Returns minimal dose for the radical diffusion model
  *
  * @param[in]   E_MeV_u		energy in MeV/u
- * @param[in]   particle_no		TODO
- * @param[in]   material_no		TODO
+ * @param[in]  particle_no  type of the particles
+ * @see          AT_DataParticle.h for definition
+ * @param[in]  material_no  material index
+ * @see          AT_DataMaterial.h for definition
  * @return      minimal dose in Gy
  */
 double	 AT_d_min_RadicalDiffusion_Gy( const double E_MeV_u,
@@ -117,7 +119,8 @@ double	 AT_d_min_RadicalDiffusion_Gy( const double E_MeV_u,
  * Returns maximum dose for the radical diffusion model
  *
  * @param[in]   E_MeV_u		energy in MeV/u
- * @param[in]   particle_no		TODO
+ * @param[in]  particle_no  type of the particles
+ * @see          AT_DataParticle.h for definition
  * @param[in]   material_no		TODO
  * @return      maximum dose in Gy
  */

--- a/include/AT_RDD_Tabulated.h
+++ b/include/AT_RDD_Tabulated.h
@@ -105,6 +105,8 @@ double	 AT_r_max_RadicalDiffusion_m( const double E_MeV_u);
  * Returns minimal dose for the radical diffusion model
  *
  * @param[in]   E_MeV_u		energy in MeV/u
+ * @param[in]   particle_no		TODO
+ * @param[in]   material_no		TODO
  * @return      minimal dose in Gy
  */
 double	 AT_d_min_RadicalDiffusion_Gy( const double E_MeV_u,
@@ -115,6 +117,8 @@ double	 AT_d_min_RadicalDiffusion_Gy( const double E_MeV_u,
  * Returns maximum dose for the radical diffusion model
  *
  * @param[in]   E_MeV_u		energy in MeV/u
+ * @param[in]   particle_no		TODO
+ * @param[in]   material_no		TODO
  * @return      maximum dose in Gy
  */
 double	 AT_d_max_RadicalDiffusion_Gy( const double E_MeV_u,

--- a/include/AT_StoppingPowerDataBethe.h
+++ b/include/AT_StoppingPowerDataBethe.h
@@ -98,6 +98,7 @@ double AT_Bethe_Stopping_Number(	const double 	E_MeV_u,
  * @param[in]      material_no  material index
  * @see          AT_DataMaterial.h for definition
  * @param[in]      E_restricted_keV 	if positive and smaller than maximally transferable energy, the restricted stopping power will be computed
+ * @param[in]      use_effective_charge 	TODO
  * @return     result
  */
 double AT_Bethe_energy_loss_MeV_cm2_g_single(	const double 	E_MeV_u,
@@ -117,6 +118,7 @@ double AT_Bethe_energy_loss_MeV_cm2_g_single(	const double 	E_MeV_u,
  * @param[in]      material_no  material index (single value)
  * @see          AT_DataMaterial.h for definition
  * @param[in]      E_restricted_keV 	if positive and smaller than maximally transferable energy, the restricted stopping power will be computed (single value)
+ * @param[in]      use_effective_charge 	TODO
  * @param[out]     Mass_Stopping_Power_MeV_cm2_g (array of size n)
  */
 void AT_Bethe_energy_loss_MeV_cm2_g(	const long n,


### PR DESCRIPTION
For cBinder project, it was necessary to add parameter descriptions to doxygen comments, where they were omitted.