### PR TITLE
Fix CMake deprecation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(amtrack)
 

--- a/example/basic_plots/CMakeLists.txt
+++ b/example/basic_plots/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(amtrack_plots)
 

--- a/example/demo/CMakeLists.txt
+++ b/example/demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.2)
 
 project(amtrack_demo)
 
@@ -14,7 +14,7 @@ target_link_libraries( ${PROJECT_NAME} LINK_PUBLIC amtrack ${GSL_LIBRARIES})
 # You must avoid adding it as a link library when building for Windows.
 # see https://stackoverflow.com/questions/54935559/linking-math-library-in-cmake-file-on-windows-and-linux
 IF (NOT WIN32)
-  target_link_libraries (${PROJECT_NAME} m)
+  target_link_libraries (${PROJECT_NAME} LINK_PUBLIC m)
 ENDIF()
 
 

--- a/example/demo/CMakeLists.txt
+++ b/example/demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(amtrack_demo)
 


### PR DESCRIPTION
This is my PR for issue #223

The bumped minimum version of CMake are fixed for Linux and Windows(MSYS2)

About the `LINK_PUBLIC`, you need to add same keyword signature too when using the `target_link_libraries` more than once, please see: https://stackoverflow.com/a/59522268

fix #223 