### PR TITLE
Add macOS build and test to GitHub Actions

### DIFF
--- a/.github/workflows/macos-reusable.yml
+++ b/.github/workflows/macos-reusable.yml
@@ -1,0 +1,40 @@
+name: macOS Build & Test
+
+on:
+  workflow_call:
+    # (Add inputs if needed later)
+
+jobs:
+  build_and_test_macos:
+    runs-on: macos-latest
+    outputs:
+      macos_status: ${{ job.status }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install system packages
+        run: brew install gsl
+
+      - name: Build & Install libamtrack (macOS)
+        run: |
+          mkdir build && cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake --build . --parallel
+          cmake --install . --prefix "${{ runner.temp }}/usr"
+      
+      - name: Run macOS Tests
+        run: |
+          export PATH="${{ runner.temp }}/usr/bin:$PATH"
+          export DYLD_LIBRARY_PATH="${{ runner.temp }}/usr/lib:$DYLD_LIBRARY_PATH"
+          amtrack_test
+          amtrack_demo
+
+      - name: Upload macOS Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: libamtrack-macos
+          path: "${{ runner.temp }}/usr/"
+          if-no-files-found: error
+          retention-days: 5

--- a/.github/workflows/macos-reusable.yml
+++ b/.github/workflows/macos-reusable.yml
@@ -2,7 +2,11 @@ name: macOS Build & Test
 
 on:
   workflow_call:
-    # (Add inputs if needed later)
+    inputs:
+      linux_status:
+        description: 'Status of the Linux Build job'
+        required: true
+        type: string
 
 jobs:
   build_and_test_macos:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,14 @@ jobs:
     name: Linux Build & Test
     uses: ./.github/workflows/linux-reusable.yml
 
+  build_and_test_macos:
+    name: macOS Build & Test
+    needs: build_and_test_linux
+    if: ${{ needs.build_and_test_linux.result == 'success' }}
+    uses: ./.github/workflows/macos-reusable.yml
+    with:
+      linux_status: ${{ needs.build_and_test_linux.result }}
+
   build_and_test_windows:
     name: Windows Build & Test
     needs: build_and_test_linux


### PR DESCRIPTION
Related to #259

Add macOS build and test job to GitHub Actions workflow.

* Modify `.github/workflows/main.yml` to include a new job `build_and_test_macos` after `build_and_test_linux`.
* Add a new reusable workflow file `.github/workflows/macos-reusable.yml` for macOS build and test.
* Define steps in `macos-reusable.yml` for checking out the code, installing dependencies, building, testing, and uploading artifacts for macOS.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/libamtrack/library/pull/260?shareId=ffc95664-4757-451b-95c9-b3afc268cf93).