### PR TITLE
Potential fix for code scanning alert no. 1: Multiplication result converted to larger type

### DIFF
--- a/src/AT_Algorithms_GSM.c
+++ b/src/AT_Algorithms_GSM.c
@@ -655,7 +655,7 @@ void AT_GSM_multiple_local_dose_distrib( const long  number_of_field_components,
 		}
 
 		*mean_d_check_Gy		+=	cur_d_check_Gy;
-		*sd_d_check_Gy			+=	cur_d_check_Gy * cur_d_check_Gy;
+		*sd_d_check_Gy			+=	(double)cur_d_check_Gy * cur_d_check_Gy;
 	}
 
 	/* Effective calculation of running mean and stdev of x in n runs: */


### PR DESCRIPTION
Potential fix for [https://github.com/libamtrack/library/security/code-scanning/1](https://github.com/libamtrack/library/security/code-scanning/1)

To fix the problem, we need to ensure that the multiplication is performed using `double` precision to avoid overflow. This can be achieved by casting one of the operands to `double` before performing the multiplication. This way, the multiplication will be done using `double` precision, and the result will not overflow.

- Cast `cur_d_check_Gy` to `double` before performing the multiplication.
- Update the assignment on line 658 to use the casted value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
