### PR TITLE
Fix compile error in AT_lambda_Vavilov_FWHM under GCC 16 / C23

### DIFF
--- a/src/AT_EnergyLoss.c
+++ b/src/AT_EnergyLoss.c
@@ -484,7 +484,7 @@ double AT_lambda_Vavilov_FWHM_right(const double kappa, const double beta) {
 }
 
 double AT_lambda_Vavilov_FWHM(const double kappa, const double beta) {
-    return (AT_lambda_Vavilov_FWHM_right(kappa, beta) - AT_lambda_Landau_FWHM_left(kappa, beta));
+    return (AT_lambda_Vavilov_FWHM_right(kappa, beta) - AT_lambda_Vavilov_FWHM_left(kappa, beta));
 }
 
 double AT_energy_loss_keV_Vavilov_FWHM(const double E_MeV_u,


### PR DESCRIPTION
## Summary

`AT_lambda_Vavilov_FWHM` in `src/AT_EnergyLoss.c` called `AT_lambda_Landau_FWHM_left(kappa, beta)`, but `AT_lambda_Landau_FWHM_left` is declared and defined with **no parameters**. Under C17 and earlier, an empty parameter list `()` in a non-prototype declaration meant "unspecified arguments," so compilers tolerated the extra arguments. C23 (the default standard in GCC 16) changes this: `()` now means the function takes exactly zero parameters, so the call becomes a hard compile error ("too many arguments to function").

The correct counterpart to `AT_lambda_Vavilov_FWHM_right(kappa, beta)` is `AT_lambda_Vavilov_FWHM_left(kappa, beta)`, which already exists in the same file and takes `kappa`/`beta` — it was simply the wrong function being called.

```c
// before
double AT_lambda_Vavilov_FWHM(const double kappa, const double beta) {
    return (AT_lambda_Vavilov_FWHM_right(kappa, beta) - AT_lambda_Landau_FWHM_left(kappa, beta));
}

// after
double AT_lambda_Vavilov_FWHM(const double kappa, const double beta) {
    return (AT_lambda_Vavilov_FWHM_right(kappa, beta) - AT_lambda_Vavilov_FWHM_left(kappa, beta));
}
```

This also fixes a latent logic bug: `AT_lambda_Vavilov_FWHM` was mixing a Vavilov-distribution FWHM-right value with a Landau-distribution FWHM-left value (a constant, independent of `kappa`/`beta`), instead of using the matching Vavilov-distribution left value.

## Test plan

- [x] Reproduced the exact compiler diagnostic ("too many arguments to function") with a minimal repro compiled under `-std=c2x` (C23 semantics), confirming this is the root cause of the GCC 16 failure.
- [x] Compiled `src/AT_EnergyLoss.c` standalone with `gcc -std=c2x` after the fix — no errors.
- [ ] Full CMake/CI build (not run locally in this environment; will be verified by CI on this PR).

Fixes #287

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKcZZgDrQbv716oMCgJJZY)_